### PR TITLE
Incorrect link to IRSA ZTF Overview in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ https://irsa.ipac.caltech.edu/frontpage/
 | Question  | Answer |
 | ------------- | ------------- |
 | ztfquery documentation  | https://github.com/MickaelRigault/ztfquery  |
-| ZTF table content  | https://irsa.ipac.caltech.edu/onlinehelp/ztf/overview.html  |
+| ZTF table content  | https://irsa.ipac.caltech.edu/onlinehelp/ztf  |
 | Alerts content  | https://zwickytransientfacility.github.io/ztf-avro-alert/schema.html |
 |What is the  "Redshift Completeness Factor" program? | It's a program dedicated to determine the number of SN host galaxies with known spectroscopic redshift prior to  the SN discovery divided by the total number of SN hosts. See https://arxiv.org/abs/1910.12973 |
 |What is the  "Census of the Local Unverse" program? | The Census of the Local Universe (CLU) aims to provide a galaxy catalog out to 200 Mpc that is as complete as possible. See https://arxiv.org/abs/1710.05016 |


### PR DESCRIPTION
The link from the readme doesn't work for me. This PR changes that link to what I believe is the right one.